### PR TITLE
Add testnet faucet for sepolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ https://www.infura.io/faucet
 
 https://getblock.io/faucet/eth-sepolia/
 
+https://cloud.google.com/application/web3/faucet/ethereum/sepolia/
+
 ### ETH 2.0
 
 #### Kiln Testnet (beta)


### PR DESCRIPTION
Google Cloud recently launched a Sepolia faucet: https://cloud.google.com/application/web3/faucet/ethereum/sepolia/

which grants 0.05 Sepolia Test ETH per day.