### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ https://getblock.io/faucet/eth-sepolia/
 
 https://cloud.google.com/application/web3/faucet/ethereum/sepolia/
 
+https://getsepolia.2bd.net/
+
 ### ETH 2.0
 
 #### Kiln Testnet (beta)


### PR DESCRIPTION
Adds GetSepolia to the Sepolia faucet list.

GetSepolia is a free, open-source Sepolia faucet providing 0.02 Sepolia ETH every 24 hours without requiring an account, wallet connection, or mainnet balance.

Thanks for maintaining the testnet faucet lists!